### PR TITLE
Provide ability to allow user to use config option to disable cron option: Minutes, Years, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ The component takes an attribute of `config`
 
 ### Options
 
+This is an object in your controller you can use to remove options from the user. For example if you would like the user to be able to set Minute, Hour, and Day but not Week, Month, and Year you would create the following object in your controller:
+
+```json
+{
+    quartz: true,
+    multiple: false,
+    options : {
+      minute : false
+    }
+}
+```
 
 ## Development
 

--- a/src/app/lib/contracts/contracts.ts
+++ b/src/app/lib/contracts/contracts.ts
@@ -12,6 +12,7 @@ export interface CronJobsConfig {
   quartz?: boolean;
   multiple?: boolean;
   bootstrap?: boolean;
+  option?: {};
 }
 
 export interface CronJobsFrequency {

--- a/src/app/lib/contracts/contracts.ts
+++ b/src/app/lib/contracts/contracts.ts
@@ -26,8 +26,18 @@ export interface CronJobsFrequency {
 
 export interface CronJobsSelectOption {
   value: number;
+  type?: OptionType;
   label: string | number;
 }
+
+export enum OptionType {
+  minute,
+  hour,
+  day,
+  week,
+  month,
+  year
+  }
 
 export interface CronJobsValidationConfig {
   validate?: boolean;

--- a/src/app/lib/cron-jobs/cron-jobs.component.spec.ts
+++ b/src/app/lib/cron-jobs/cron-jobs.component.spec.ts
@@ -294,6 +294,20 @@ describe('CronJobsComponent', () => {
     expect(component.minutesData.length).toBeTruthy();
   }));
 
+  it('should set corect base freq data for select options', fakeAsync(() => {
+
+    testComponent.cronConfig = {
+      ...testComponent.cronConfig,
+      option: { minute: false },
+    };
+
+    testFixture.detectChanges();
+    const expected = ['Please select', 'Hour', 'Day', 'Week', 'Month', 'Year'];
+    tick();
+    expect(Object.values(component.baseFrequencyData).map(x => x.label)).toEqual(expected);
+
+  }));
+
   it('should on init patch cronJobsFrom with default value', fakeAsync(() => {
     testFixture.detectChanges();
     const spy = spyOn(component.cronJobsForm, 'patchValue').and.callThrough();

--- a/src/app/lib/cron-jobs/cron-jobs.component.ts
+++ b/src/app/lib/cron-jobs/cron-jobs.component.ts
@@ -97,7 +97,14 @@ export class CronJobsComponent implements OnInit, OnChanges, OnDestroy, ControlV
         this.onChange(this.cronService.setCron(values));
       });
 
-    this.baseFrequencyData = this.dataService.baseFrequency;
+    let baseFreq = this.dataService.baseFrequency;
+
+    if (this.config.option) {
+      baseFreq = baseFreq.filter(x => !(this.config.option.hasOwnProperty(x.label.toString().toLowerCase()) && !this.config.option[x.label])
+      );
+    }
+
+    this.baseFrequencyData = baseFreq;
     this.daysOfMonthData = this.dataService.daysOfMonth;
     this.daysOfWeekData = this.dataService.getDaysOfWeek(false);
     this.monthsData = this.dataService.months;

--- a/src/app/lib/cron-jobs/cron-jobs.component.ts
+++ b/src/app/lib/cron-jobs/cron-jobs.component.ts
@@ -4,7 +4,8 @@ import {
 } from '@angular/core';
 import {
   CronJobsConfig, CronJobsFrequency, CronJobsSelectOption,
-  CronJobsValidationConfig
+  CronJobsValidationConfig,
+  OptionType
 } from '../contracts/contracts';
 import { DataService } from '../services/data.service';
 import { ControlValueAccessor, FormBuilder, FormControl, FormGroup, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -56,8 +57,8 @@ export class CronJobsComponent implements OnInit, OnChanges, OnDestroy, ControlV
   private cronService: PosixService;
 
   constructor(private dataService: DataService,
-              private injector: Injector,
-              private formBuilder: FormBuilder) {
+    private injector: Injector,
+    private formBuilder: FormBuilder) {
 
     this.cronJobsForm = this.formBuilder.group({
       baseFrequency: 0,
@@ -92,7 +93,7 @@ export class CronJobsComponent implements OnInit, OnChanges, OnDestroy, ControlV
       .subscribe((values: CronJobsFrequency) => {
         if (!values.baseFrequency) {
           values = this.cronService.getDefaultFrequenceWithDefault();
-          this.cronJobsForm.patchValue(values, {emitEvent: false});
+          this.cronJobsForm.patchValue(values, { emitEvent: false });
         }
         this.onChange(this.cronService.setCron(values));
       });
@@ -100,7 +101,8 @@ export class CronJobsComponent implements OnInit, OnChanges, OnDestroy, ControlV
     let baseFreq = this.dataService.baseFrequency;
 
     if (this.config.option) {
-      baseFreq = baseFreq.filter(x => !(this.config.option.hasOwnProperty(x.label.toString().toLowerCase()) && !this.config.option[x.label])
+      baseFreq = baseFreq.filter(x => !(this.config.option.hasOwnProperty(OptionType[x.type])
+        && !this.config.option[OptionType[x.type]])
       );
     }
 
@@ -129,7 +131,7 @@ export class CronJobsComponent implements OnInit, OnChanges, OnDestroy, ControlV
         if (!changes['config'].previousValue ||
           changes['config'].previousValue['quartz'] !== changes['config'].currentValue['quartz']) {
           this.daysOfWeekData = this.dataService.getDaysOfWeek(this.config.quartz);
-          this.cronJobsForm.patchValue({daysOfWeek: this.daysOfWeekData[0].value});
+          this.cronJobsForm.patchValue({ daysOfWeek: this.daysOfWeekData[0].value });
         }
       });
       this.setService();

--- a/src/app/lib/fixture.spec.ts
+++ b/src/app/lib/fixture.spec.ts
@@ -1,11 +1,13 @@
+import { OptionType } from './contracts/contracts';
+
 export const baseFrequency = [
   {value: 0, label: 'Please select'},
-  {value: 1, label: 'Minute'},
-  {value: 2, label: 'Hour'},
-  {value: 3, label: 'Day'},
-  {value: 4, label: 'Week'},
-  {value: 5, label: 'Month'},
-  {value: 6, label: 'Year'}
+  {value: 1, type: OptionType.minute, label: 'Minute'},
+  {value: 2, type: OptionType.hour, label: 'Hour'},
+  {value: 3, type: OptionType.day, label: 'Day'},
+  {value: 4, type: OptionType.week, label: 'Week'},
+  {value: 5, type: OptionType.month, label: 'Month'},
+  {value: 6, type: OptionType.year, label: 'Year'}
 ];
 
 export const numeral = [

--- a/src/app/lib/services/data.service.ts
+++ b/src/app/lib/services/data.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CronJobsConfig, CronJobsSelectOption, CronJobsValidationConfig } from '../contracts/contracts';
+import { CronJobsConfig, CronJobsSelectOption, CronJobsValidationConfig, OptionType } from '../contracts/contracts';
 
 @Injectable()
 export class DataService {
@@ -84,13 +84,13 @@ export class DataService {
   ];
 
   private _baseFrequency: Array<CronJobsSelectOption> = [
-    {value: 0, label: 'Please select'},
-    {value: 1, label: 'Minute'},
-    {value: 2, label: 'Hour'},
-    {value: 3, label: 'Day'},
-    {value: 4, label: 'Week'},
-    {value: 5, label: 'Month'},
-    {value: 6, label: 'Year'}
+    { value: 0, label: 'Please select' },
+    { value: 1, type: OptionType.minute, label: 'Minute' },
+    { value: 2, type: OptionType.hour, label: 'Hour' },
+    { value: 3, type: OptionType.day, label: 'Day' },
+    { value: 4, type: OptionType.week, label: 'Week' },
+    { value: 5, type: OptionType.month, label: 'Month' },
+    { value: 6, type: OptionType.year, label: 'Year' }
   ];
 
   private _hours: Array<CronJobsSelectOption>;


### PR DESCRIPTION
Similar to https://github.com/angular-cron-jobs/angular-cron-jobs
See ###Options

@yp2 Thanks for the feedback. Move this pr here for ease communication. 
Could you elaborate more on adding this to CronJobsSelectOption? As far as I understand, there is no external way to modify the array of CronJobsSelectOption (frequencies). And similarly how the js version of this implemented this feature.

You can see the updated readme doc in this pr for some example too.
Thanks.